### PR TITLE
Accept paths for files in malwareconfig

### DIFF
--- a/app/dockerotools.py
+++ b/app/dockerotools.py
@@ -16,7 +16,7 @@ from subprocess import DEVNULL, STDOUT, check_call, check_output
 
 dockerotools = Starlette(debug=True)
 SAMPLEPATH="/data/badshit/"
-DECODERS=['kevin','jurg']
+DECODERS=['kevin'] #,'jurg']
 DECODERSPATH='/opt/decoders/'
 
 ##exception handlers
@@ -54,6 +54,8 @@ async def malconf(request):
                 #     raise HTTPException(status_code=412)
             elif package == 'jurg':
                 # move file to tmp
+                if not os.path.exists(os.path.dirname('/tmp/'+request.path_params['filename'])):
+                    os.makedirs(os.path.dirname('/tmp/'+request.path_params['filename']))
                 shutil.copyfile(filepath,'/tmp/'+request.path_params['filename'])
                 # execute qrypter
                 check_call(['python3', DECODERSPATH+'java_malware_tools-master/unpackers/qrypter/current-qrypter.py', '/tmp/'+request.path_params['filename']], stdout=DEVNULL, stderr=DEVNULL)

--- a/app/dockerotools.py
+++ b/app/dockerotools.py
@@ -35,7 +35,7 @@ async def server_error(request, exc):
 async def homepage(request):
     return JSONResponse({'hello': 'don\'t just sit there and send me some info @malwareconfig endpoint.'})
 
-@dockerotools.route('/malwareconfig/{filename}')
+@dockerotools.route('/malwareconfig/{filename:path}')
 async def malconf(request):
     filepath=SAMPLEPATH + request.path_params['filename']
     if path.exists(filepath):


### PR DESCRIPTION
Adding path parameter to route allows passing subpaths instead of only filenames (accepts slashes)

Thanks to JB for the testing help